### PR TITLE
Terminal mode(s) for TinySSD1306 and small fixes

### DIFF
--- a/src/tiny_ssd1306.cpp
+++ b/src/tiny_ssd1306.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2017 Alexey Dynda
-    Copyright (C) 2017 Kidelo
+    Copyright (C) 2017 Kidelo <kidelo@yahoo.com>
 
     This file is part of SSD1306 library.
 
@@ -18,12 +18,30 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/**
+ * @file tiny_ssd1306.cpp Drawing in memory buffer
+ */
+
 #include "tiny_ssd1306.h"
 #include "intf/ssd1306_interface.h"
 #include "lcd/ssd1306_commands.h"
 
+void TinySSD1306::clear()
+{
+  ssd1306_clearScreen();
+
+  // back to home
+  ssd1306_sendCommand( SSD1306_SETSTARTLINE | 0 );
+
+  // reset position
+  m_xpos = m_ypos = 0;
+};
+
 size_t TinySSD1306::write(uint8_t ch)
 {
+    // normal height
+    const uint8_t HEIGHT = ( height() / FONT_Y_SIZE );
+
     // skip non printable chars and prepare the line
     const char str[2] = { static_cast<char>( ch < ' ' ? '_' : ch ), '\0' };
 
@@ -35,7 +53,7 @@ size_t TinySSD1306::write(uint8_t ch)
     const bool lf  = '\n' == ch;
 
     // skip print of char
-    const bool skip = cr || lf;
+    bool skip = cr || lf;
 
     // carriage return requested or EOL in text ?
     if ( eol || cr )
@@ -47,23 +65,59 @@ size_t TinySSD1306::write(uint8_t ch)
     if ( eol || m_pending_lf )
     {
         m_ypos += 1;
-    }
 
-    // new line outside display requested
-    if ( m_ypos >= ( height() / FONT_Y_SIZE ) )
-    {
-        // jump to home
-        m_ypos = 0;
+        // new line outside display requested
+        if ( m_ypos >= HEIGHT )
+        {
+          // redraw on last line ...
+          if ( T_MODE_OVERRIDE == m_mode )
+          {
+            // stay on position
+            m_ypos = HEIGHT-1;
 
-        // clear display
-        clear();
-    }
+            // clear this line ( only some parts are overwritten by next characters )
+            clearBlock( 0, m_ypos, width(), FONT_Y_SIZE );
+          }
+
+          // scrolling of text ?
+          if ( T_MODE_SCROLLING == m_mode )
+          {
+            // second round over
+            if ( m_ypos >= ( 2 * HEIGHT ) )
+            {
+              // reset to scrolling range
+              m_ypos = HEIGHT;
+            }
+
+            // there is window of HEIGHT of text in display buffer, shift to last line that can be displayed
+            const uint8_t shift_to = (( ( m_ypos - HEIGHT + 1 ) * FONT_Y_SIZE ) & ~SSD1306_SETSTARTLINE);
+
+            // shift line ( has nothing to do with position of data in RAM )
+            ssd1306_sendCommand( SSD1306_SETSTARTLINE | shift_to );
+
+            // clear this line ( only some parts are overwritten by next characters )
+            clearBlock( 0, m_ypos, width(), FONT_Y_SIZE );
+          }
+
+          // reset screen ?
+          if ( T_MODE_CLEAR == m_mode )
+          {
+            // clear display
+            clear();
+          }
+
+        } // end of if()
+
+    } // end of if()
 
     // print it ?
     if ( !skip )
     {
+        // use original position for write
+        const uint8_t ypos = ( m_ypos < HEIGHT ) ? m_ypos : m_ypos - HEIGHT;
+
         // normal processing
-        ssd1306_charF6x8( m_xpos, m_ypos, str, STYLE_NORMAL );
+        ssd1306_charF6x8( m_xpos, ypos, str, STYLE_NORMAL );
 
         // forward
         m_xpos += FONT_X_SIZE;

--- a/src/tiny_ssd1306.h
+++ b/src/tiny_ssd1306.h
@@ -55,6 +55,13 @@
 class TinySSD1306: public Print
 {
 public:
+
+    enum
+    {
+      FONT_X_SIZE = 6,
+      FONT_Y_SIZE = 8
+    };
+
     /**
      * Creates object for communicating with LCD display.
      * @param lcd - initialization callback for LCD
@@ -111,19 +118,19 @@ public:
     /**
      * Returns display height in pixels
      */
-    uint8_t      height() { ssd1306_displayHeight(); };
+    uint8_t      height() { return ssd1306_displayHeight(); };
 
     /**
      * Returns display width in pixels
      */
-    uint8_t      width() { ssd1306_displayWidth(); };
+    uint8_t      width() { return ssd1306_displayWidth(); };
 
     /**
      * Sets position in terms of display for text output (Print class).
      * @param x - horizontal position in pixels
      * @param y - vertical position in blocks (pixels/8)
      */
-    void         setCursor(uint8_t x, uint8_t y) { m_xpos = x; m_ypos = y; }
+    void         setCursor(uint8_t x, uint8_t y) { m_xpos = x; m_ypos = y; m_pending_lf = false;}
 
     /**
      * Fills screen with pattern byte.
@@ -159,7 +166,7 @@ public:
     uint8_t      charF6x8(uint8_t x, uint8_t y,
                           const char ch[],
                           EFontStyle style = STYLE_NORMAL )
-    { ssd1306_charF6x8(x, y, ch, style); };
+    { return ssd1306_charF6x8(x, y, ch, style); };
 
     /**
      * Prints text to screen using double size font 12x16.
@@ -172,7 +179,7 @@ public:
     uint8_t      charF12x16(uint8_t xpos, uint8_t y,
                             const char ch[],
                             EFontStyle style = STYLE_NORMAL)
-    { ssd1306_charF12x16( xpos, y, ch, style ); };
+    { return ssd1306_charF12x16( xpos, y, ch, style ); };
 
 
     /**
@@ -191,7 +198,7 @@ public:
                               const char ch[],
                               EFontStyle style,
                               uint8_t right)
-    { ssd1306_charF6x8_eol(left, y, ch, style, right); };
+    { return ssd1306_charF6x8_eol(left, y, ch, style, right); };
 
     /**
      * Put single pixel on the LCD.
@@ -299,6 +306,9 @@ private:
 
     uint8_t      m_xpos = 0;
     uint8_t      m_ypos = 0;
+
+    /** pending line feed feed at start of next write */
+    bool         m_pending_lf = false;
 };
 
 #endif

--- a/src/tiny_ssd1306.h
+++ b/src/tiny_ssd1306.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2017 Alexey Dynda
+    Copyright (C) 2017 Kidelo <kidelo@yahoo.com>
 
     This file is part of SSD1306 library.
 
@@ -16,6 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 /**
  * @file tiny_ssd1306.h Drawing in memory buffer
  */
@@ -47,19 +49,46 @@
  * {
  *      lcd.beginI2C();
  *
+ *      // using direct write
  *      lcd.clear();
  *      lcd.charF6x8(0,0,"Hello");
- * }
+ *
+ *      // using Print::print interface
+ *      lcd.print('s');
+ *      lcd.print("sd");
+ *      lcd.print(1306);
+ *      lcd.println();
+ *      lcd.println("ssd1306");
+ *
+  * }
  * ~~~~~~~~~~~~~~~
  */
+
 class TinySSD1306: public Print
 {
 public:
 
+  /**
+   * Some common constants
+   */
     enum
     {
       FONT_X_SIZE = 6,
       FONT_Y_SIZE = 8
+    };
+
+    /**
+     * Controls the behavior of terminal mode when all lines of display are written
+     * @see TinySSD1306::write
+     * @see Print::write
+     */
+    enum TerminalMode
+    {
+      T_MODE_OVERRIDE,       /*!< OVERRIDE LAST LINE, use @see clear() to restart */
+      T_MODE_CLEAR,          /*!< CLEAR display */
+      T_MODE_SCROLLING,      /*!< SCROLL display */
+
+      MAX_T_MODE
     };
 
     /**
@@ -118,12 +147,12 @@ public:
     /**
      * Returns display height in pixels
      */
-    uint8_t      height() { return ssd1306_displayHeight(); };
+    uint8_t      height() const { return ssd1306_displayHeight(); };
 
     /**
      * Returns display width in pixels
      */
-    uint8_t      width() { return ssd1306_displayWidth(); };
+    uint8_t      width() const { return ssd1306_displayWidth(); };
 
     /**
      * Sets position in terms of display for text output (Print class).
@@ -141,7 +170,7 @@ public:
     /**
      * Fills screen with zero-byte
      */
-    void         clear() { ssd1306_clearScreen(); };
+    void         clear();
 
     /**
      * All drawing functions start to work in negative mode.
@@ -304,11 +333,18 @@ private:
     /** lcd display initialization function */
     InitFunction m_init;
 
+    /** internal positions used for write()  */
     uint8_t      m_xpos = 0;
     uint8_t      m_ypos = 0;
 
     /** pending line feed feed at start of next write */
     bool         m_pending_lf = false;
+
+    /** terminal mode when using ::write()
+     *
+     *  note: use const for compiler optimization ( dead code ) without #defines
+     */
+    static const TerminalMode m_mode = T_MODE_CLEAR;
 };
 
 #endif


### PR DESCRIPTION
* Some coding issues corrected
* Make TinySSD1306::write compatible to Print::write
* Added extended character control 
  - Support for \r (CR) and \n (LF)
  - LF is defered to start of next line, allows usage of Print::println() for all lines
* add terminal modes, see enum TerminalMode
  T_MODE_OVERRIDE,       /*!< OVERRIDE LAST LINE to restart */
  T_MODE_CLEAR,          /*!< CLEAR display */
  T_MODE_SCROLLING,      /*!< SCROLL display */