### PR TITLE
Add contrast control for ssd1306

### DIFF
--- a/src/ssd1306.c
+++ b/src/ssd1306.c
@@ -93,6 +93,13 @@ void ssd1306_displayOn()
     ssd1306_sendCommand(SSD1306_DISPLAYON);
 }
 
+void ssd1306_setContrast(uint8_t contrast){
+    ssd1306_commandStart();
+    ssd1306_sendByte(SSD1306_SETCONTRAST);
+    ssd1306_sendByte(contrast);
+    ssd1306_endTransmission();
+}
+
 uint8_t ssd1306_printFixed(uint8_t xpos, uint8_t y, const char ch[], EFontStyle style)
 {
     uint8_t i, j=0;

--- a/src/ssd1306.c
+++ b/src/ssd1306.c
@@ -93,7 +93,8 @@ void ssd1306_displayOn()
     ssd1306_sendCommand(SSD1306_DISPLAYON);
 }
 
-void ssd1306_setContrast(uint8_t contrast){
+void ssd1306_setContrast(uint8_t contrast)
+{
     ssd1306_commandStart();
     ssd1306_sendByte(SSD1306_SETCONTRAST);
     ssd1306_sendByte(contrast);

--- a/src/ssd1306.h
+++ b/src/ssd1306.h
@@ -62,6 +62,11 @@ void         ssd1306_displayOff();
 void         ssd1306_displayOn();
 
 /**
+ * Set display contrast, ie light intensity
+ */
+void         ssd1306_setContrast(uint8_t contrast);
+
+/**
  * Switches display to inverse mode.
  * LCD will display 0-pixels as white, and 1-pixels as black.
  * @note Not supported for SSD1331

--- a/src/ssd1306.h
+++ b/src/ssd1306.h
@@ -63,6 +63,7 @@ void         ssd1306_displayOn();
 
 /**
  * Set display contrast, ie light intensity
+ * @param contrast - contrast value to see, refer to ssd1306 datasheet
  */
 void         ssd1306_setContrast(uint8_t contrast);
 


### PR DESCRIPTION
This allows to control the display contrast / intensity as defined in the SSD1306 specs.
Only tested on Arduino Uno because I have no other device, but it should work the same since this is quite straightforward.


Note: the current master build fails because of a warning in src/i2c/ssd1306_i2c_twi.c:50. I fixed it on my local repo without commiting it, so you won't be able to build this PR without updating it