### PR TITLE
Giant character: 24x32 and 48x64 font

### DIFF
--- a/src/ssd1306.c
+++ b/src/ssd1306.c
@@ -425,7 +425,7 @@ uint8_t ssd1306_charF24x32(uint8_t xpos, uint8_t y, const char ch[], EFontStyle 
             }
 			//Drawing
             data >>= 8/mult*cnt; //move next 4 bits cnt dependent
-			//Doubles the char (operatore ternario ?:) 
+			//Doubles the char
             data = ((data & 0x01) ? 0x0F: 0x00) |
                    ((data & 0x02) ? 0xF0: 0x00);
             for(uint8_t m=0;m<mult;m++)	ssd1306_sendByte(data^s_invertByte);//n column duplication
@@ -448,7 +448,7 @@ uint8_t ssd1306_charF48x64(uint8_t xpos, uint8_t y, const char ch[], EFontStyle 
     ssd1306_dataStart();
     for(;;)
     {
-		//Reset checkings
+	//Reset checkings
         if( (x > s_displayWidth-6*mult) || (ch[j] == '\0') ) //or x is not inside or end of string
         {
             x = xpos;
@@ -468,7 +468,7 @@ uint8_t ssd1306_charF48x64(uint8_t xpos, uint8_t y, const char ch[], EFontStyle 
         }
         uint8_t c = ch[j] - 32; //char offset from string table
         uint8_t ldata = 0;
-		//Drawing routine
+	//Drawing routine
         for(i=0;i<6;i++)	//read x data
         {
             uint8_t data;
@@ -487,7 +487,7 @@ uint8_t ssd1306_charF48x64(uint8_t xpos, uint8_t y, const char ch[], EFontStyle 
             }
 			//Drawing
             data >>= 8/mult*cnt; //move next 4 bits cnt dependent
-			//Doubles the char (operatore ternario ?:) 
+		//Doubles the char 
             data = ((data & 0x01) ? 0xFF: 0x00);
             for(uint8_t m=0;m<mult;m++)	ssd1306_sendByte(data^s_invertByte);//n column duplication
         }

--- a/src/ssd1306.h
+++ b/src/ssd1306.h
@@ -177,7 +177,7 @@ uint8_t      ssd1306_charF6x8(uint8_t x, uint8_t y,
 /**
  * Prints text to screen using double size font 12x16.
  * @param xpos - horizontal position in pixels
- * @param y - vertical position in blocks (pixels/8)
+ * @param y - vertical position in blocks (pixels/16)
  * @param ch - NULL-terminated string to print
  * @param style - font style (EFontStyle).
  * @returns number of chars in string
@@ -186,6 +186,33 @@ uint8_t      ssd1306_charF12x16(uint8_t xpos,
                                 uint8_t y,
                                 const char ch[],
                                 EFontStyle style);
+    
+/**
+ * Prints text to screen using double size font 24x32.
+ * @param xpos - horizontal position in pixels
+ * @param y - vertical position in blocks (pixels/32)
+ * @param ch - NULL-terminated string to print
+ * @param style - font style (EFontStyle).
+ * @returns number of chars in string
+ */
+uint8_t      ssd1306_charF24x32(uint8_t xpos,
+                                uint8_t y,
+                                const char ch[],
+                                EFontStyle style);
+								
+/**
+ * Prints text to screen using double size font 48x64.
+ * @param xpos - horizontal position in pixels
+ * @param y - vertical position in blocks (pixels/64)
+ * @param ch - NULL-terminated string to print
+ * @param style - font style (EFontStyle).
+ * @returns number of chars in string
+ */
+uint8_t      ssd1306_charF48x64(uint8_t xpos,
+                                uint8_t y,
+                                const char ch[],
+                                EFontStyle style);
+
 
 
 /**

--- a/src/ssd1306.h
+++ b/src/ssd1306.h
@@ -185,7 +185,7 @@ uint8_t      ssd1306_charF6x8(uint8_t x, uint8_t y,
 uint8_t      ssd1306_charF12x16(uint8_t xpos,
                                 uint8_t y,
                                 const char ch[],
-                                EFontStyle style);
+                                EFontStyle style); 
     
 /**
  * Prints text to screen using double size font 24x32.


### PR DESCRIPTION
I've used the same workflow of 12x16 character to create the other 24x32 and 48x64 size character. They work fine expecially for "long" distance of view. They don't increase memory usage as 12x16. Obviously only few characters at time can be displayed for these sets. The 48x64 can display only two char in the 128x64 display.