### PR TITLE
Refactor ssd1306_platform_i2cInit to commonize all platform signatures

### DIFF
--- a/src/intf/i2c/ssd1306_i2c.c
+++ b/src/intf/i2c/ssd1306_i2c.c
@@ -28,7 +28,10 @@
 void ssd1306_i2cInitEx(int8_t scl, int8_t sda, int8_t sa)
 {
 #if defined(CONFIG_PLATFORM_I2C_AVAILABLE) && defined(CONFIG_PLATFORM_I2C_ENABLE)
-    ssd1306_platform_i2cInit(scl, sa, sda);
+    ssd1306_platform_i2cConfig_t cfg;
+    cfg.scl = scl;
+    cfg.sda = sda;
+    ssd1306_platform_i2cInit(-1, sa, &cfg);
 #elif defined(CONFIG_TWI_I2C_AVAILABLE) && defined(CONFIG_TWI_I2C_ENABLE)
     ssd1306_i2cConfigure_Twi(0);
     ssd1306_i2cInit_Twi(sa);

--- a/src/ssd1306_hal/arduino/platform.cpp
+++ b/src/ssd1306_hal/arduino/platform.cpp
@@ -101,12 +101,12 @@ static void ssd1306_i2cClose_Wire()
 {
 }
 
-void ssd1306_platform_i2cInit(int8_t scl, uint8_t sa, int8_t sda)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg)
 {
 #if defined(ESP8266) || defined(ESP32) || defined(ESP31B)
-    if ((scl >= 0) && (sda >=0))
+    if ((cfg->scl >= 0) && (cfg->sda >=0))
     {
-        Wire.begin(sda, scl);
+        Wire.begin(cfg->sda, cfg->scl);
     }
     else
 #endif
@@ -117,7 +117,7 @@ void ssd1306_platform_i2cInit(int8_t scl, uint8_t sa, int8_t sda)
         Wire.setClock(400000);
     #endif
 
-    if (sa) s_sa = sa;
+    if (sa) s_sa = addr;
     ssd1306_intf.spi = 0;
     ssd1306_intf.start = ssd1306_i2cStart_Wire;
     ssd1306_intf.stop = ssd1306_i2cStop_Wire;

--- a/src/ssd1306_hal/esp/platform.c
+++ b/src/ssd1306_hal/esp/platform.c
@@ -129,9 +129,9 @@ void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cCo
     s_bus_id = busId;
     i2c_config_t conf;
     conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = cfg->sda; // I2C_EXAMPLE_MASTER_SDA_IO;
+    conf.sda_io_num = cfg->sda;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_io_num = cfg->scl; // I2C_EXAMPLE_MASTER_SCL_IO;
+    conf.scl_io_num = cfg->scl;
     conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
     conf.master.clk_speed = 400000; //I2C_EXAMPLE_MASTER_FREQ_HZ;
     i2c_param_config(s_bus_id, &conf);

--- a/src/ssd1306_hal/esp/platform.c
+++ b/src/ssd1306_hal/esp/platform.c
@@ -115,7 +115,7 @@ static void platform_i2c_send_buffer(const uint8_t *data, uint16_t len)
 //    i2c_master_write(cmd, data_wr, size, ACK_CHECK_EN);
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg)
 {
     if (addr) s_i2c_addr = addr;
     ssd1306_intf.spi = 0;
@@ -129,9 +129,9 @@ void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg)
     s_bus_id = busId;
     i2c_config_t conf;
     conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = 21; // I2C_EXAMPLE_MASTER_SDA_IO;
+    conf.sda_io_num = cfg->sda; // I2C_EXAMPLE_MASTER_SDA_IO;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
-    conf.scl_io_num = 22; // I2C_EXAMPLE_MASTER_SCL_IO;
+    conf.scl_io_num = cfg->scl; // I2C_EXAMPLE_MASTER_SCL_IO;
     conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
     conf.master.clk_speed = 400000; //I2C_EXAMPLE_MASTER_FREQ_HZ;
     i2c_param_config(s_bus_id, &conf);

--- a/src/ssd1306_hal/io.h
+++ b/src/ssd1306_hal/io.h
@@ -74,6 +74,11 @@ extern "C" {
 
 // !!! PLATFORM I2C IMPLEMENTATION OPTIONAL !!!
 #if defined(CONFIG_PLATFORM_I2C_AVAILABLE) && defined(CONFIG_PLATFORM_I2C_ENABLE)
+typedef struct {
+    uint16_t sda;
+    uint16_t scl;
+} ssd1306_platform_i2cConfig_t;
+
 /**
  * @brief Initializes i2c interface for platform being used.
  *
@@ -90,7 +95,7 @@ extern "C" {
  *        for AVR it is used as sda pin number. If you want to use default pin number, please
  *        pass -1.
  */
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg);
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg);
 #endif
 
 

--- a/src/ssd1306_hal/io.h
+++ b/src/ssd1306_hal/io.h
@@ -86,14 +86,12 @@ typedef struct {
  * depends on platform.
  *
  * @param busId i2c bus number. Some platforms have several i2c buses. so, this
- *        argument identifies bus to use. For AVR platforms busId is used as scl
- *        pin number. If you want to use default i2c bus for specific platform, please
- *        pass -1.
+ *        argument identifies bus to use. For several platforms busId is not used.
+ *        If you want to use default i2c bus for specific platform, please pass -1.
  * @param addr i2c address of oled driver, connected to i2c bus. If you want to use default
  *        i2c display address, please, pass 0.
- * @param arg additional parameter for i2c interface. Not used on many platforms, while
- *        for AVR it is used as sda pin number. If you want to use default pin number, please
- *        pass -1.
+ * @param cfg Specify scl and sda for the platform. If you want to use default pin numbers,
+ *        please pass -1 for both members.
  */
 void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg);
 #endif

--- a/src/ssd1306_hal/linux/platform.c
+++ b/src/ssd1306_hal/linux/platform.c
@@ -325,7 +325,7 @@ static void empty_function_two_args(const uint8_t *arg1, uint16_t arg2)
 {
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, ssd1306_platform_i2cConfig_t * cfg)
 {
     char filename[20];
     if (busId < 0)
@@ -373,7 +373,7 @@ static void platform_i2c_send_buffer(const uint8_t *buffer, uint16_t size)
     };
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, ssd1306_platform_i2cConfig_t * cfg)
 {
     sdl_core_init();
     ssd1306_intf.spi = 0;
@@ -568,7 +568,7 @@ void ssd1306_platform_spiInit(int8_t busId, int8_t ces, int8_t dcPin)
 
 #else  // end of !KERNEL, KERNEL is below
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, ssd1306_platform_i2cConfig_t * cfg)
 {
 }
 

--- a/src/ssd1306_hal/mingw/platform.c
+++ b/src/ssd1306_hal/mingw/platform.c
@@ -116,7 +116,7 @@ static void empty_function_two_args(const uint8_t *arg1, uint16_t arg2)
 {
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, ssd1306_platform_i2cConfig_t * cfg)
 {
     char filename[20];
     if (busId < 0)
@@ -163,7 +163,7 @@ static void platform_i2c_send_buffer(const uint8_t *buffer, uint16_t size)
     };
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t sa, ssd1306_platform_i2cConfig_t * cfg)
 {
     sdl_core_init();
     ssd1306_intf.spi = 0;

--- a/src/ssd1306_hal/stm32/platform.c
+++ b/src/ssd1306_hal/stm32/platform.c
@@ -61,7 +61,7 @@ static void platform_i2c_send_buffer(const uint8_t *data, uint16_t len)
     // ... Send len bytes to i2c communication channel here
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg)
 {
     if (addr) s_i2c_addr = addr;
     if (HAL_I2C_IsDeviceReady(&hi2c1, s_i2c_addr, 1, 20000) != HAL_OK)

--- a/src/ssd1306_hal/template/io.h
+++ b/src/ssd1306_hal/template/io.h
@@ -142,7 +142,7 @@ static inline char *utoa(unsigned int num, char *str, int radix)    // util utoa
 
 // !!! PLATFORM I2C IMPLEMENTATION OPTIONAL !!!
 #if defined(CONFIG_PLATFORM_I2C_AVAILABLE) && defined(CONFIG_PLATFORM_I2C_ENABLE)
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg);
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg);
 #endif
 
 

--- a/src/ssd1306_hal/template/platform.c
+++ b/src/ssd1306_hal/template/platform.c
@@ -59,7 +59,7 @@ static void platform_i2c_send_buffer(const uint8_t *data, uint16_t len)
     // ... Send len bytes to i2c communication channel here
 }
 
-void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, int8_t arg)
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t * cfg)
 {
     if (addr) s_i2c_addr = addr;
     ssd1306_intf.spi = 0;


### PR DESCRIPTION
Initial attempt at a solution for #68.

This implementation refactors ssd1306_platform_i2cInit to use a config structure instead of the generic arg value that is used now.  This approach allows the signature to remain the same across all platforms, but is now flexible enough to support setting all of the required fields in the more complicated platforms like esp32.

The public APIs for I2C init (`ssd1306_i2cInit` and `ssd1306_i2cInitEx`) are not impacted.  This does, however, change the way that ssd1306_platform_i2cInit is called, but it doesn't appear that this is intended to be a public facing API.  If anyone is currently using this API directly in a consuming project, I would expect compilation errors (or at least warnings) since the type for the third arg has changed from a uint8_t to a pointer.

Please note that I only tested this on the esp32 (IDF) platform as I don't have any of the other setups readily available.