### PR TITLE
Support custom SPI bus config for ESP platform

### DIFF
--- a/src/ssd1306_hal/esp/platform.c
+++ b/src/ssd1306_hal/esp/platform.c
@@ -275,9 +275,21 @@ void ssd1306_platform_spiInit(int8_t busId,
     // init your interface here
     spi_bus_config_t buscfg=
     {
+#ifdef SSD1306_ESP_MISO_NUM
+        .miso_io_num= SSD1306_ESP_MISO_NUM,
+#else
         .miso_io_num= s_spi_bus_id ? 19 : 12,
+#endif
+#ifdef SSD1306_ESP_MOSI_NUM
+        .mosi_io_num= SSD1306_ESP_MOSI_NUM,
+#else
         .mosi_io_num= s_spi_bus_id ? 23 : 13,
+#endif
+#ifdef SSD1306_ESP_SCLK_NUM
+        .sclk_io_num= SSD1306_ESP_SCLK_NUM,
+#else
         .sclk_io_num= s_spi_bus_id ? 18 : 14,
+#endif
         .quadwp_io_num=-1,
         .quadhd_io_num=-1,
         .max_transfer_sz=32


### PR DESCRIPTION
I want to use this library for [M5StickC](https://docs.m5stack.com/#/en/core/m5stickc/) and [M5StickV](https://docs.m5stack.com/#/en/core/m5stickv). These devices have custom configured SPI bus (mosi=15, sclk=13,..).
Manual fix of `spi_bus_config_t` is required in order to use this ssd1306 library with them (See what I changed).
I made these bus numbers configurable with compile-time definition.
