### PR TITLE
Additional initialization delay for for ili9341

### DIFF
--- a/src/lcd/lcd_ili9341.c
+++ b/src/lcd/lcd_ili9341.c
@@ -221,6 +221,7 @@ void   ili9341_240x320_spi_init(int8_t rstPin, int8_t cesPin, int8_t dcPin)
         digitalWrite(rstPin, LOW);
         delay(100);
         digitalWrite(rstPin, HIGH);
+        delay(100);
     }
     s_ssd1306_spi_clock = 10000000;
     ssd1306_spiInit(cesPin, dcPin);


### PR DESCRIPTION
Fix for the garbling issue reported in https://github.com/lexus2k/ssd1306/issues/101