### PR TITLE
esp: Initialise i2c_config_t struct to 0

### DIFF
--- a/src/ssd1306_hal/esp/platform.c
+++ b/src/ssd1306_hal/esp/platform.c
@@ -138,7 +138,7 @@ void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cCo
     // init your interface here
     if ( busId < 0) busId = I2C_NUM_1;
     s_bus_id = busId;
-    i2c_config_t conf;
+    i2c_config_t conf = { 0 };
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = cfg->sda >= 0 ? cfg->sda : 21;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;


### PR DESCRIPTION
Recent versions of the ESP SDK (>=4.3) have added extra fields to the i2c_config_t struct which need to be set to zero, otherwise the following errors are printed out:

    E (322) i2c: i2c_param_config(644): i2c clock choice is invalid, please check flag and frequency
    E (1344) i2c: i2c_set_pin(825): scl and sda gpio numbers are the same

Initialising the struct to zero resolves these issues.

See https://github.com/espressif/esp-idf/issues/6293 for more information on this.