### PR TITLE
Added support for the 0.1USD Ch32v003 RISC-V MCU

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@
 * [drgallaci](https://github.com/drgallaci)
 * [CromFr](https://gitbug.com/CromFr)
 * [montaguk](https://github.com/montaguk)
+* [ldab](https://github.com/ldab)
 
 ## Special thanks to
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ through API.
 | [SDL Emulation](https://github.com/lexus2k/ssd1306/wiki/How-to-run-emulator-mode) |  X  |  X  | demo code can be run without real OLED HW via MinGW32 + SDL library |
 | **Energia**  |    |     |          |
 | MSP432P401R |  X  |  X  |  |
+| **WCH32**  |    |     |          |
+| WCH32V003 |  X  |      |          |
 
 Digispark users, please check compilation options in your Arduino prior to using this library.
 Ssd1306 library requires at least c++11 and c99 (by default Digispark package misses the options
@@ -119,12 +121,18 @@ Ssd1306 library requires at least c++11 and c99 (by default Digispark package mi
 
 *i2c Hardware setup is described [here](https://github.com/lexus2k/ssd1306/wiki/Hardware-setup)*
 
-*Setting up for Arduino from github sources)*
+*Setting up for Arduino from github sources*
  * Download source from https://github.com/lexus2k/ssd1306
  * Put the sources to Arduino/libraries/ssd1306/ folder
 
 *Setting up for Arduino from Arduino IDE library manager*
  * Install ssd1306 library (named ssd1306 by Alexey Dynda) via Arduino IDE library manager
+
+*Setting up for PlatformIO*
+  * Open platformio.ini, a project configuration file located in the root of PlatformIO project.
+  * Add the following line to the lib_deps option of [env:] section:
+    `lexus2k/ssd1306`
+  * Build a project, PlatformIO will automatically install dependencies.
 
 *Using with plain avr-gcc:*
  * Download source from https://github.com/lexus2k/ssd1306
@@ -138,6 +146,10 @@ Ssd1306 library requires at least c++11 and c99 (by default Digispark package mi
   * Download source from https://github.com/lexus2k/ssd1306
   * Put downloaded sources to components/ssd1306/ folder.
   * Compile your project as described in ESP-IDF build system documentation
+
+ *For wch32v003:*
+* Can be build using PlaftormIO, add the following line to `platformio.ini` file:
+    `platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git`
 
 For more information about this library, please, visit https://github.com/lexus2k/ssd1306.
 Doxygen documentation can be found at [github.io site](http://lexus2k.github.io/ssd1306).

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -32,6 +32,7 @@ SRCS_C = \
 	ssd1306_hal/linux/platform.c \
 	ssd1306_hal/mingw/platform.c \
 	ssd1306_hal/stm32/platform.c \
+	ssd1306_hal/ch32v/platform.c \
 	ssd1306_hal/template/platform.c \
 	intf/i2c/ssd1306_i2c.c \
 	intf/i2c/ssd1306_i2c_embedded.c \

--- a/src/ssd1306_hal/ch32v/io.h
+++ b/src/ssd1306_hal/ch32v/io.h
@@ -1,0 +1,97 @@
+/*
+    MIT License
+
+    Copyright (c) 2018, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+/*
+ * @file ssd1306_hal/ch32v/io.h This is ch32v platform file
+ */
+
+#ifndef _SSD1306_CH32V_IO_H_
+#define _SSD1306_CH32V_IO_H_
+
+#define SSD1306_CH32V_PLATFORM
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* If your platform already has these definitions, comment out lines below */
+#define LOW    0
+#define HIGH   1
+#define INPUT  0
+#define OUTPUT 1
+
+/* Progmem attribute for data, located in Flash */
+#define PROGMEM
+
+#define CONFIG_PLATFORM_I2C_AVAILABLE
+// #define CONFIG_PLATFORM_SPI_AVAILABLE // TODO
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int digitalRead(int pin) // digitalRead()
+{
+  return LOW;
+}
+
+static inline void digitalWrite(int pin, int level) // digitalWrite()
+{
+}
+
+static inline void pinMode(int pin, int mode) // pinMode()
+{
+}
+
+static inline int analogRead(int pin) // analogRead()
+{
+  return 0;
+}
+
+static inline uint32_t millis(void) // millis()
+{
+  return 0;
+}
+
+static inline uint32_t micros(void) // micros()
+{
+  return 0;
+};
+
+void delay(uint32_t ms);
+
+static inline void delayMicroseconds(uint32_t us) // delayMicroseconds()
+{
+}
+
+static inline uint8_t pgm_read_byte(const void *ptr) // pgm_read_byte() - can be left as is
+{
+  return *((const uint8_t *)ptr);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/ssd1306_hal/ch32v/platform.c
+++ b/src/ssd1306_hal/ch32v/platform.c
@@ -1,0 +1,181 @@
+/*
+    MIT License
+
+    Copyright (c) 2018, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#include "ssd1306_hal/io.h"
+
+#if defined(SSD1306_CH32V_PLATFORM)
+
+#include "debug.h"
+#include "intf/ssd1306_interface.h"
+
+void delay(uint32_t ms)
+{
+  Delay_Ms(ms); //
+}
+
+#if defined(CONFIG_PLATFORM_I2C_AVAILABLE) && defined(CONFIG_PLATFORM_I2C_ENABLE)
+static uint8_t s_i2c_addr = 0x3C;
+
+static void platform_i2c_start(void)
+{
+  while (I2C_GetFlagStatus(I2C1, I2C_FLAG_BUSY) != RESET) {
+    ;
+  }
+
+  I2C_GenerateSTART(I2C1, ENABLE);
+
+  while (!I2C_CheckEvent(I2C1, I2C_EVENT_MASTER_MODE_SELECT)) {
+    ;
+  }
+
+  I2C_Send7bitAddress(I2C1, s_i2c_addr << 1, I2C_Direction_Transmitter);
+
+  while (!I2C_CheckEvent(I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED)) {
+    ;
+  }
+}
+
+static void platform_i2c_stop(void)
+{
+  // wait for last byte transmitted
+  while (!I2C_CheckEvent(I2C1, I2C_STAR1_BTF)) {
+    ;
+  }
+  I2C_GenerateSTOP(I2C1, ENABLE);
+}
+
+static void platform_i2c_send(uint8_t data)
+{
+  // wait for last byte transmitted
+  while (I2C_GetFlagStatus(I2C1, I2C_FLAG_TXE) == RESET) {
+    ;
+  }
+  I2C_SendData(I2C1, data); // send data byte
+}
+
+static void platform_i2c_close(void)
+{
+  I2C_Cmd(I2C1, DISABLE); //
+}
+
+static void platform_i2c_send_buffer(const uint8_t *data, uint16_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    platform_i2c_send(data[i]);
+  }
+}
+
+void ssd1306_platform_i2cInit(int8_t busId, uint8_t addr, ssd1306_platform_i2cConfig_t *cfg)
+{
+  (void)busId; // busId not used, only 1x I2C
+  (void)cfg;   // todo, pin number depends on the footprint, a layer arduino-ish in between here is needed, use default.
+
+  if (addr) {
+    s_i2c_addr = addr;
+  }
+
+  ssd1306_intf.spi         = 0;
+  ssd1306_intf.start       = &platform_i2c_start;
+  ssd1306_intf.stop        = &platform_i2c_stop;
+  ssd1306_intf.send        = &platform_i2c_send;
+  ssd1306_intf.close       = &platform_i2c_close;
+  ssd1306_intf.send_buffer = &platform_i2c_send_buffer;
+
+  RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC | RCC_APB2Periph_AFIO, ENABLE);
+  RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C1, ENABLE);
+
+  GPIO_InitTypeDef GPIO_InitStructure = {
+      .GPIO_Pin   = GPIO_Pin_2,
+      .GPIO_Mode  = GPIO_Mode_AF_OD,
+      .GPIO_Speed = GPIO_Speed_30MHz,
+  };
+  GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+  GPIO_InitStructure.GPIO_Pin   = GPIO_Pin_1;
+  GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF_OD;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_30MHz;
+  GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+  I2C_InitTypeDef I2C_InitTSturcture = {
+      .I2C_ClockSpeed          = 40000,
+      .I2C_Mode                = I2C_Mode_I2C,
+      .I2C_DutyCycle           = I2C_DutyCycle_16_9,
+      .I2C_Ack                 = I2C_Ack_Enable,
+      .I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit,
+  };
+  I2C_Init(I2C1, &I2C_InitTSturcture);
+
+  I2C_Cmd(I2C1, ENABLE);
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// TODO
+#if defined(CONFIG_PLATFORM_SPI_AVAILABLE) && defined(CONFIG_PLATFORM_SPI_ENABLE)
+
+#include "intf/spi/ssd1306_spi.h"
+
+static void platform_spi_start(void)
+{
+  // ... Open spi channel for your device with specific s_ssd1306_cs, s_ssd1306_dc
+}
+
+static void platform_spi_stop(void)
+{
+  // ... Complete spi communication
+}
+
+static void platform_spi_send(uint8_t data)
+{
+  // ... Send byte to spi communication channel
+}
+
+static void platform_spi_close(void)
+{
+  // ... free all spi resources here
+}
+
+static void platform_spi_send_buffer(const uint8_t *data, uint16_t len)
+{
+  // ... Send len bytes to spi communication channel here
+}
+
+void ssd1306_platform_spiInit(int8_t busId, int8_t cesPin, int8_t dcPin)
+{
+  if (cesPin >= 0)
+    s_ssd1306_cs = cesPin;
+  if (dcPin >= 0)
+    s_ssd1306_dc = dcPin;
+  ssd1306_intf.spi         = 1;
+  ssd1306_intf.start       = &platform_spi_start;
+  ssd1306_intf.stop        = &platform_spi_stop;
+  ssd1306_intf.send        = &platform_spi_send;
+  ssd1306_intf.close       = &platform_spi_close;
+  ssd1306_intf.send_buffer = &platform_spi_send_buffer;
+  // init your interface here
+  //...
+}
+#endif
+
+#endif // YOUR_PLATFORM

--- a/src/ssd1306_hal/io.h
+++ b/src/ssd1306_hal/io.h
@@ -53,6 +53,8 @@
 #include "mingw/io.h"
 #elif defined(ENERGIA)
 #include "energia/io.h"
+#elif defined(CH32V00X)
+#include "ch32v/io.h"
 #else
 #warning "Platform is not supported. Use template to add support"
 #include "template/io.h"


### PR DESCRIPTION
I have added I2C support for the CH32V003 Risc-v MCU, I cooked my display so will need to wait another week to get it working on the HW, but we can start a review just to see if I get things right.