### PR TITLE
Fix for fatal error: driver/gpio.h: No such file or directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT DEFINED COMPONENT_DIR)
 else()
 
     idf_component_register(SRCS ${SOURCE_FILES}
-                           INCLUDE_DIRS "src")
+                           INCLUDE_DIRS "src"
+                           REQUIRES    driver)
 
 endif()


### PR DESCRIPTION
Resolves an issue when using the library with `espidf` framework.
```cpp
components/ssd1306/src/ssd1306_hal/esp/platform.c:33:10: fatal error: driver/gpio.h: No such file or directory
   33 | #include "driver/gpio.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.
Compiling .pio/build/esp32dev/components/ssd1306/src/ssd1306_hal/template/platform.c.o
*** [.pio/build/esp32dev/components/ssd1306/src/ssd1306_hal/esp/platform.c.o] Error 1
```
It is now needed to specifically require the driver in `components/ssd1306/CMakeLists.txt`:
```diff
     idf_component_register(SRCS ${SOURCE_FILES}
-                           INCLUDE_DIRS "src")
+                           INCLUDE_DIRS "src"
+                           REQUIRES    driver)
```

Tested on
```
PLATFORM: Espressif 32 (6.9.0) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
PACKAGES: 
 - framework-espidf @ 3.50301.0 (5.3.1) 
 - tool-cmake @ 3.16.4 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - tool-ninja @ 1.7.1 
 - tool-riscv32-esp-elf-gdb @ 12.1.0+20221002 
 - tool-xtensa-esp-elf-gdb @ 12.1.0+20221002 
 - toolchain-esp32ulp @ 1.23800.240113 (2.38.0) 
 - toolchain-xtensa-esp-elf @ 13.2.0+20240530
 ```
