### PR TITLE
Add DISABLE options to UserSettings.h

### DIFF
--- a/src/ssd1306_hal/UserSettings.h
+++ b/src/ssd1306_hal/UserSettings.h
@@ -45,49 +45,70 @@
  *          header file, and gain another 100-200 bytes of RAM and 300-500 bytes of Flash.
  */
 
-/* Comment out options below if you don't need support in the library,  *
- * and want to reduce memory consumption.                               */
+/* To disable unused library features and save memory,         *
+ * define the corresponding SSD1306_xxxxxx_DISABLE options.    */
 
-/** Define this macro if you need to enable software I2C module for compilation */
+
+/** Define SSD1306_SOFTWARE_I2C_DISABLE to exclude software I2C module from compilation. */
+#ifndef SSD1306_SOFTWARE_I2C_DISABLE
 #define CONFIG_SOFTWARE_I2C_ENABLE
+#endif
 
-/** Define this macro if you need to enable TWI I2C module for compilation */
+/** Define SSD1306_TWI_I2C_DISABLE to exclude TWI I2C module from compilation. */
+#ifndef SSD1306_TWI_I2C_DISABLE
 #define CONFIG_TWI_I2C_ENABLE
+#endif
 
-/** Define this macro if you need to enable AVR SPI module for compilation */
+/** Define SSD1306_AVR_SPI_DISABLE to exclude AVR SPI module from compilation. */
+#ifndef SSD1306_AVR_SPI_DISABLE
 #define CONFIG_AVR_SPI_ENABLE
+#endif
 
-/** Define this macro if you need to enable USI SPI module for compilation */
+/** Define SSD1306_USI_SPI_DISABLE to exclude USI SPI module from compilation. */
+#ifndef SSD1306_USI_SPI_DISABLE
 #define CONFIG_USI_SPI_ENABLE
+#endif
 
-/** Define this macro if you need to enable AVR UART module for compilation */
+/** Define SSD1306_AVR_UART_DISABLE to exclude AVR UART module from compilation. */
+#ifndef SSD1306_AVR_UART_DISABLE
 #define CONFIG_AVR_UART_ENABLE
+#endif
 
-/** Define this macro if you need to enable VGA module for compilation */
+/** Define SSD1306_VGA_DISABLE to exclude VGA module from compilation. */
+#ifndef SSD1306_VGA_DISABLE
 #define CONFIG_VGA_ENABLE
+#endif
 
 /** Define this macro if you need to enable Adafruit GFX canvas support for compilation */
-#ifndef CONFIG_ADAFRUIT_GFX_ENABLE
 //#define CONFIG_ADAFRUIT_GFX_ENABLE
+
+/**
+ * Define SSD1306_PLATFORM_I2C_DISABLE to disable the platform-specific I2C interface
+ * implemented in SSD1306 HAL.
+ * 
+ * If you use Arduino platform, this lets you skip compilation of the Wire library.
+ */
+#ifndef SSD1306_PLATFORM_I2C_DISABLE
+#define CONFIG_PLATFORM_I2C_ENABLE
 #endif
 
 /**
- * Define this macro if platform specific i2c interface is implemented in SSD1306 HAL.
- * If you use Arduino platform, this macro enables Arduino Wire library module for compilation.
+ * Define SSD1306_PLATFORM_SPI_DISABLE to disable the platform-specific SPI interface
+ * implemented in SSD1306 HAL.
+ * 
+ * If you use Arduino platform, this lets you skip compilation of the SPI library.
  */
-#define CONFIG_PLATFORM_I2C_ENABLE
-
-/**
- * Define this macro if platform specific spi interface is implemented in SSD1306 HAL
- * If you use Arduino platform, this macro enables Arduino SPI library module for compilation.
- */
+#ifndef SSD1306_PLATFORM_SPI_DISABLE
 #define CONFIG_PLATFORM_SPI_ENABLE
+#endif
 
 /**
- * Defines, whenever ssd1306 library supports unicode.
- * Support of unicode increases RAM and Flasg memory consumption
+ * Define SSD1306_UNICODE_DISABLE to disable this library's unicode support.
+ * Unicode support increases RAM and Flash memory consumption.
  */
+#ifndef SSD1306_UNICODE_DISABLE
 #define CONFIG_SSD1306_UNICODE_ENABLE
+#endif
 
 /**
  * @}


### PR DESCRIPTION
Hello,
This is a nice library! I've been using this library with an ATtiny system, so minimizing memory usage is critical for sure.

My proposed changes make it easier to use the library's configuration options.

---

In the library's current state, it's necessary to comment out various `_ENABLE` options in `ssd1306_hal/UserSettings.h`, since they're basically all enabled by default:
```c
// UserSettings.h

/**
 * Define this macro if platform specific spi interface is implemented in SSD1306 HAL
 * If you use Arduino platform, this macro enables Arduino SPI library module for compilation.
 */
//#define CONFIG_PLATFORM_SPI_ENABLE   // don't need this

/**
 * Defines, whenever ssd1306 library supports unicode.
 * Support of unicode increases RAM and Flasg memory consumption
 */
//#define CONFIG_SSD1306_UNICODE_ENABLE   // don't need this either.
```
Unfortunately, this forces the user to modify the source code just to use the configuration options. This is rather inconvenient.

My proposal is to wrap the `CONFIG_xxxxxx_ENABLE` defines with `#ifndef SSD1306_xxxxxx_DISABLE` conditions, like so:

```c
// UserSettings.h

/**
 * Define SSD1306_PLATFORM_SPI_DISABLE to disable the platform-specific SPI interface
 * implemented in SSD1306 HAL.
 * 
 * If you use Arduino platform, this lets you skip compilation of the SPI library.
 */
#ifndef SSD1306_PLATFORM_SPI_DISABLE
#define CONFIG_PLATFORM_SPI_ENABLE
#endif

/**
 * Define SSD1306_UNICODE_DISABLE to disable this library's unicode support.
 * Unicode support increases RAM and Flash memory consumption.
 */
#ifndef SSD1306_UNICODE_DISABLE
#define CONFIG_SSD1306_UNICODE_ENABLE
#endif
```
With this change, the various library features can be easily disabled with build flags, like `-DSSD1306_UNICODE_DISABLE`.

---

The driving philosophy behind this change is that defines can easily be added at build time, but `define` statements in the code cannot be undone without changing the source code.

* My changes won't break existing code.
* The new "disable" macro names follow the pattern `SSD1306_`*option name*`_DISABLE` to prevent potential clashing.
* The `CONFIG_xxxxxx_ENABLE` macros are still used within the library code. Only the way they're *defined* in `UserSettings.h` has been changed.
* *I removed the `#ifndef CONFIG_ADAFRUIT_GFX_ENABLE` line, since it didn't do anything. I left the option commented out, since `-DCONFIG_ADAFRUIT_GFX_ENABLE` can be passed to enable it.*

Thanks for considering- and again, great library.
-- Winston M